### PR TITLE
Reorganize Discord bot packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # Nayeo
+
+This repository contains a simple Discord Text-To-Speech bot skeleton using [discord.py](https://discordpy.readthedocs.io/en/stable/).
+Currently it only implements a `/ping` slash command that replies with `Pong!`.
+The code is organised into the following folders:
+
+- `config` – configuration helpers
+- `commands/general` – general-purpose bot commands (e.g. `ping`)
+- `tts` – TTS engine stubs
+
+## Requirements
+
+- Python 3.9+
+- `ffmpeg` installed and accessible in the `PATH`
+- Discord bot token with `message_content` intent enabled
+
+Python dependencies are listed in `requirements.txt`.
+
+## Running locally
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Set the required environment variable and start the bot:
+
+```bash
+export DISCORD_TOKEN=YOUR_TOKEN
+python bot.py
+```
+
+## Docker
+
+You can build and run the bot using Docker:
+
+```bash
+docker build -t nayeo-bot .
+docker run -e DISCORD_TOKEN=YOUR_TOKEN nayeo-bot
+```
+
+`ffmpeg` is installed in the container image.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,24 @@
+import discord
+from discord.ext import commands
+
+from config.settings import get_token
+from commands.general import ping
+
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+
+
+@bot.event
+async def on_ready():
+    await bot.tree.sync()
+    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
+
+
+# Register commands
+ping.setup(bot)
+
+
+if __name__ == "__main__":
+    bot.run(get_token())

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Command domain packages."""

--- a/commands/general/__init__.py
+++ b/commands/general/__init__.py
@@ -1,0 +1,1 @@
+"""General purpose commands."""

--- a/commands/general/ping.py
+++ b/commands/general/ping.py
@@ -1,0 +1,10 @@
+import discord
+from discord.ext import commands
+
+
+def setup(bot: commands.Bot) -> None:
+    """Register the ping slash command."""
+
+    @bot.tree.command(name="ping", description="Replies with Pong")
+    async def ping(interaction: discord.Interaction):
+        await interaction.response.send_message("Pong!")

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration package."""

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,19 @@
+import os
+
+
+def get_token() -> str:
+    """Return the Discord bot token from the environment."""
+    token = os.getenv("DISCORD_TOKEN")
+    if not token:
+        raise RuntimeError("DISCORD_TOKEN environment variable not set")
+    return token
+
+
+def get_channel_id() -> str | None:
+    """Return the text channel ID the bot listens to, if set."""
+    return os.getenv("CHANNEL_ID")
+
+
+def get_model_path() -> str | None:
+    """Return the ONNX model path for TTS, if set."""
+    return os.getenv("MODEL_PATH")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+discord.py>=2.0.0
+onnxruntime
+numpy
+soundfile

--- a/tts/__init__.py
+++ b/tts/__init__.py
@@ -1,0 +1,1 @@
+"""TTS related modules."""

--- a/tts/engine.py
+++ b/tts/engine.py
@@ -1,0 +1,10 @@
+class TTSEngine:
+    """Placeholder TTS engine using an ONNX model."""
+
+    def __init__(self, model_path: str):
+        self.model_path = model_path
+        # Actual model loading would go here
+
+    def synthesize(self, text: str) -> bytes:
+        """Return PCM16 audio bytes for the given text (stub)."""
+        raise NotImplementedError("TTS synthesis not implemented")


### PR DESCRIPTION
## Summary
- rename `설정` to `config`
- group commands by domain under `commands/` (ping moved to `commands/general`)
- move TTS code to top-level `tts`
- update imports in `bot.py` and documentation in `README`

## Testing
- `pip install -r requirements.txt`
- `python bot.py` *(fails: `DISCORD_TOKEN environment variable not set`)*

------
https://chatgpt.com/codex/tasks/task_e_6848737daf708321bbd2fb72fbce1ed9